### PR TITLE
Optimize query patterns

### DIFF
--- a/routes/recruiting.py
+++ b/routes/recruiting.py
@@ -41,16 +41,36 @@ def get_recruiting_class():
     if not team_id or not season_id:
         return jsonify({'error': 'team_id and season_id are required'}), 400
 
-    recruits = []
-    for p in Player.query.filter_by(team_id=team_id, current_year='FR').all():
-        # Find the first PlayerSeason for this player
-        first_ps = PlayerSeason.query.filter_by(player_id=p.player_id).order_by(PlayerSeason.season_id).first()
-        if first_ps and first_ps.season_id == season_id:
-            recruits.append({
-                'player_id': p.player_id,
-                'name': p.name,
-                'position': p.position,
-                'recruit_stars': p.recruit_stars,
-                'recruit_rank_nat': p.recruit_rank_nat
-            })
-    return jsonify(recruits) 
+    from sqlalchemy import func
+
+    first_season_sub = (
+        db.session.query(
+            PlayerSeason.player_id,
+            func.min(PlayerSeason.season_id).label('first_season')
+        )
+        .group_by(PlayerSeason.player_id)
+        .subquery()
+    )
+
+    query = (
+        db.session.query(Player)
+        .join(first_season_sub, Player.player_id == first_season_sub.c.player_id)
+        .filter(
+            Player.team_id == team_id,
+            Player.current_year == 'FR',
+            first_season_sub.c.first_season == season_id
+        )
+    )
+
+    recruits = [
+        {
+            'player_id': p.player_id,
+            'name': p.name,
+            'position': p.position,
+            'recruit_stars': p.recruit_stars,
+            'recruit_rank_nat': p.recruit_rank_nat
+        }
+        for p in query.all()
+    ]
+
+    return jsonify(recruits)


### PR DESCRIPTION
## Summary
- remove repeated conference lookups when building standings
- prefetch opponent names for dashboard game summaries
- join players for roster and stat leader routes
- prefetch award, recruit and transfer lookups
- avoid repeated conference queries in promotion/relegation logic
- fetch recruiting classes with a single query

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685aef75423c8324ba35c54f70f6f60a