### PR TITLE
Improve rankings page with types and optimizations

### DIFF
--- a/frontend/components/sortable-team-row.tsx
+++ b/frontend/components/sortable-team-row.tsx
@@ -1,0 +1,39 @@
+import { GripVertical } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import React from "react";
+
+interface SortableTeamRowProps {
+  team: { team_id: number };
+  index: number;
+  children: React.ReactNode;
+}
+
+export default function SortableTeamRow({ team, index, children }: SortableTeamRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: team.team_id });
+  const style: React.CSSProperties = {
+    transform: transform ? CSS.Transform.toString(transform) : undefined,
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+    >
+      {children}
+      <button
+        className="ml-4 cursor-grab active:cursor-grabbing p-1 text-gray-400 hover:text-gray-600"
+        type="button"
+        {...attributes}
+        {...listeners}
+        tabIndex={-1}
+        aria-label="Drag to reorder"
+      >
+        <GripVertical className="w-5 h-5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -1,0 +1,25 @@
+export interface Conference {
+  conference_id: number;
+  name: string;
+}
+
+export interface Season {
+  season_id: number;
+  year: number;
+}
+
+export interface Team {
+  team_id: number;
+  team_name: string;
+  conference_name?: string;
+  conference?: string;
+  logo_url?: string;
+  final_rank?: number | null;
+  wins?: number | null;
+  losses?: number | null;
+  conference_wins?: number | null;
+  conference_losses?: number | null;
+  points_for?: number | null;
+  points_against?: number | null;
+  rank?: number;
+}


### PR DESCRIPTION
## Summary
- introduce shared `Conference`, `Season`, and `Team` interfaces
- extract sortable row into its own component
- clean up rankings page and adopt new types
- update drag-and-drop update logic and input handling

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint` *(fails: ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685c454ee5e08324bb935a3e40361999