### PR TITLE
Fix recruiting page JSX

### DIFF
--- a/frontend/app/recruiting/page.tsx
+++ b/frontend/app/recruiting/page.tsx
@@ -165,7 +165,7 @@ export default function RecruitingPage() {
                   name="height"
                   value={form.height}
                   onChange={handleFormChange}
-                  placeholder="Height (e.g. 6'2\")"
+                  placeholder={'Height (e.g. 6\'2")'}
                   className="border rounded px-2 py-1 w-24"
                   required
                 />


### PR DESCRIPTION
## Summary
- escape single quote properly in height placeholder on recruiting page

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npx next build` *(fails: prompts to install next)*

------
https://chatgpt.com/codex/tasks/task_e_686110b3e77883248b05b0292d007f71