### PR TITLE
Fix JSX syntax in modals

### DIFF
--- a/frontend/components/AddRecruitModal.tsx
+++ b/frontend/components/AddRecruitModal.tsx
@@ -175,7 +175,7 @@ export function AddRecruitModal({ form, onFormChange, onFormSubmit, loading, err
                 name="height"
                 value={form.height}
                 onChange={onFormChange}
-                placeholder="6'2\""
+                placeholder={"6'2\""}
                 required
               />
             </div>

--- a/frontend/components/AddTransferModal.tsx
+++ b/frontend/components/AddTransferModal.tsx
@@ -146,7 +146,7 @@ export function AddTransferModal({ form, onFormChange, onFormSubmit, loading, er
                 name="height"
                 value={form.height}
                 onChange={onFormChange}
-                placeholder="6'2\""
+                placeholder={"6'2\""}
                 required
               />
             </div>


### PR DESCRIPTION
## Summary
- fix placeholder escape in `AddRecruitModal`
- fix placeholder escape in `AddTransferModal`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Module '@/lib/api' has no exported member 'addAward', etc.)*
- `pnpm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68615d789be883249933eb363b81ca71