### PR TITLE
Fix roster player class history and remove graduates

### DIFF
--- a/routes/players.py
+++ b/routes/players.py
@@ -23,12 +23,19 @@ def add_player_to_team(team_id):
     position = data.get('position')
     ovr_rating = data.get('ovr_rating')
     season_id = data.get('season_id')
+    current_year = data.get('current_year', 'FR')
     if not all([name, position, ovr_rating, season_id]):
         return jsonify({'error': 'Missing required fields'}), 400
-    player = Player(name=name, position=position, team_id=team_id)
+    player = Player(name=name, position=position, team_id=team_id, current_year=current_year)
     db.session.add(player)
     db.session.commit()
-    player_season = PlayerSeason(player_id=player.player_id, season_id=season_id, team_id=team_id, ovr_rating=ovr_rating, player_class=player.current_year)
+    player_season = PlayerSeason(
+        player_id=player.player_id,
+        season_id=season_id,
+        team_id=team_id,
+        ovr_rating=ovr_rating,
+        player_class=current_year
+    )
     db.session.add(player_season)
     db.session.commit()
     return jsonify({'player_id': player.player_id, 'name': player.name, 'position': player.position}), 201

--- a/routes/season_actions.py
+++ b/routes/season_actions.py
@@ -59,6 +59,11 @@ def progress_players_logic(season_id):
         # Skip if a PlayerSeason already exists for this player in the next season (might happen for activated recruits/transfers)
         if player.player_id in existing_next_season_ps:
             continue
+        # Graduated players should not appear on future rosters
+        if player.current_year == "GR":
+            player.team_id = None
+            continue
+
         # Try to copy selected attributes (e.g., ovr_rating) from the player's most recent season record if available
         prev_ps = PlayerSeason.query.filter_by(player_id=player.player_id, season_id=season_id).first()
         ovr_rating = prev_ps.ovr_rating if prev_ps else None


### PR DESCRIPTION
## Summary
- store player's current year when adding a player
- skip creating PlayerSeason for graduates during progression so they don't show on later rosters

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866b7196a3483249f060011d6f1f9ac