### PR TITLE
Fix roster experience to reflect selected season

### DIFF
--- a/frontend/app/players/page.tsx
+++ b/frontend/app/players/page.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Search, Star, TrendingUp, Award } from "lucide-react"
 import React, { useEffect, useState } from "react"
-import { fetchPlayers, setPlayerRedshirt, addPlayer, fetchPlayersBySeason } from "@/lib/api"
+import { setPlayerRedshirt, addPlayer, fetchPlayersBySeason } from "@/lib/api"
 import { SeasonSelector } from "@/components/SeasonSelector";
 import { useSeason } from "@/context/SeasonContext";
 
@@ -47,8 +47,8 @@ export default function PlayersPage() {
     try {
       await addPlayer(form)
       setForm({ name: '', position: '', recruit_stars: 3, current_year: 'FR' })
-      if (teamId) {
-        const data = await fetchPlayers(teamId)
+      if (teamId && selectedSeason) {
+        const data = await fetchPlayersBySeason(selectedSeason, teamId)
         setPlayers(data)
       }
     } catch (err: any) {
@@ -63,8 +63,8 @@ export default function PlayersPage() {
     try {
       await setPlayerRedshirt(playerId, !current)
       // Refetch players after redshirt change
-      if (teamId) {
-        const data = await fetchPlayers(teamId)
+      if (teamId && selectedSeason) {
+        const data = await fetchPlayersBySeason(selectedSeason, teamId)
         setPlayers(data)
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- keep player experience consistent after adding or redshirting players

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` in frontend *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686783c2c2188324ae514ecadf502b93