### PR TITLE
Unify UI theme

### DIFF
--- a/frontend/components/AddRecruitModal.tsx
+++ b/frontend/components/AddRecruitModal.tsx
@@ -147,10 +147,7 @@ export function AddRecruitModal({ form, onFormChange, onFormSubmit, loading, err
 
   if (!isOpen) {
     return (
-      <Button 
-        className="bg-blue-600 hover:bg-blue-700" 
-        onClick={() => setIsOpen(true)}
-      >
+      <Button onClick={() => setIsOpen(true)}>
         Add High School Recruit
       </Button>
     );
@@ -158,7 +155,7 @@ export function AddRecruitModal({ form, onFormChange, onFormSubmit, loading, err
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg p-8 w-full max-w-2xl mx-4 shadow-xl">
+      <div className="bg-card rounded-lg p-8 w-full max-w-2xl mx-4 shadow-xl">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-semibold">Add New High School Recruit</h2>
           <Button 

--- a/frontend/components/AddTransferModal.tsx
+++ b/frontend/components/AddTransferModal.tsx
@@ -179,10 +179,7 @@ export function AddTransferModal({ form, onFormChange, onFormSubmit, loading, er
 
   if (!isOpen) {
     return (
-      <Button 
-        className="bg-purple-600 hover:bg-purple-700" 
-        onClick={() => setIsOpen(true)}
-      >
+      <Button onClick={() => setIsOpen(true)}>
         Add Transfer
       </Button>
     );
@@ -190,7 +187,7 @@ export function AddTransferModal({ form, onFormChange, onFormSubmit, loading, er
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg p-8 w-full max-w-2xl mx-4 shadow-xl">
+      <div className="bg-card rounded-lg p-8 w-full max-w-2xl mx-4 shadow-xl">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-semibold">Add New Transfer</h2>
           <Button 

--- a/frontend/components/RecruitCard.tsx
+++ b/frontend/components/RecruitCard.tsx
@@ -54,7 +54,7 @@ export function RecruitCard({ recruit, index }: RecruitCardProps) {
               <span className="text-2xl font-bold">{recruit.rating ?? '-'}</span>
               <span className="text-sm text-muted-foreground">Rating</span>
             </div>
-            <Badge className="bg-green-100 text-green-800">Committed</Badge>
+            <Badge className="bg-primary/20 text-primary">Committed</Badge>
           </div>
         </div>
       </CardHeader>

--- a/frontend/components/SeasonSelector.tsx
+++ b/frontend/components/SeasonSelector.tsx
@@ -21,7 +21,7 @@ export const SeasonSelector: React.FC = () => {
 
   return (
     <select
-      className="border border-gray-300 rounded-lg px-3 py-2 shadow-sm focus:ring-2 focus:ring-blue-200 focus:border-blue-400 bg-white text-gray-800 text-base"
+      className="border border-border rounded-lg px-3 py-2 shadow-sm focus:ring-2 focus:ring-ring focus:border-primary bg-card text-foreground text-base"
       value={selectedSeason ?? ''}
       onChange={handleChange}
     >

--- a/frontend/components/TransferCard.tsx
+++ b/frontend/components/TransferCard.tsx
@@ -31,7 +31,7 @@ export function TransferCard({ transfer, index }: TransferCardProps) {
             <div className="flex items-center gap-2 mt-1">
               <Badge variant="outline">{transfer.position}</Badge>
               {transfer.dev_trait && <Badge variant="secondary">{transfer.dev_trait}</Badge>}
-              <Badge className="bg-blue-100 text-blue-800">
+              <Badge className="bg-primary/20 text-primary">
                 <GraduationCap className="h-3 w-3 mr-1" />
                 Transfer
               </Badge>
@@ -59,7 +59,7 @@ export function TransferCard({ transfer, index }: TransferCardProps) {
                 ))}
               </div>
             )}
-            <Badge className="bg-blue-100 text-blue-800">
+            <Badge className="bg-primary/20 text-primary">
               <Building2 className="h-3 w-3 mr-1" />
               Committed
             </Badge>

--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -36,11 +36,11 @@ export function Navigation() {
   };
 
   return (
-    <nav className="bg-white shadow-sm border-b">
+    <nav className="bg-card shadow-sm border-b border-border">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
-            <Link href={getSeasonHref("/")} className="text-xl font-bold text-gray-900">
+            <Link href={getSeasonHref("/")} className="text-xl font-bold text-foreground">
               {userTeam ? userTeam.team_name : "CFB Dynasty"}
             </Link>
           </div>
@@ -56,8 +56,8 @@ export function Navigation() {
                   className={cn(
                     "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
                     pathname === item.href
-                      ? "bg-blue-100 text-blue-700"
-                      : "text-gray-600 hover:text-gray-900 hover:bg-gray-100",
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent",
                   )}
                 >
                   <Icon className="h-4 w-4" />
@@ -92,8 +92,8 @@ export function Navigation() {
                     className={cn(
                       "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
                       pathname === item.href
-                        ? "bg-blue-100 text-blue-700"
-                        : "text-gray-600 hover:text-gray-900 hover:bg-gray-100",
+                        ? "bg-primary text-primary-foreground"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent",
                     )}
                     onClick={() => setMobileMenuOpen(false)}
                   >

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -2,9 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
+
 
 @layer utilities {
   .text-balance {
@@ -14,30 +12,30 @@ body {
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 220 20% 97%;
+    --foreground: 220 20% 10%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 220 20% 10%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --popover-foreground: 220 20% 10%;
+    --primary: 220 80% 56%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 220 20% 96%;
+    --secondary-foreground: 220 20% 30%;
+    --muted: 220 14% 93%;
+    --muted-foreground: 220 14% 40%;
+    --accent: 48 96% 53%;
+    --accent-foreground: 220 20% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --border: 220 14% 90%;
+    --input: 220 14% 90%;
+    --ring: 220 80% 56%;
+    --chart-1: 211 91% 53%;
+    --chart-2: 173 80% 46%;
+    --chart-3: 43 96% 56%;
+    --chart-4: 52 98% 60%;
+    --chart-5: 27 89% 63%;
     --radius: 0.5rem;
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 240 5.3% 26.1%;
@@ -49,38 +47,38 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 220 25% 8%;
+    --foreground: 220 20% 90%;
+    --card: 220 25% 12%;
+    --card-foreground: 220 20% 90%;
+    --popover: 220 25% 12%;
+    --popover-foreground: 220 20% 90%;
+    --primary: 220 80% 66%;
+    --primary-foreground: 220 20% 10%;
+    --secondary: 220 15% 20%;
+    --secondary-foreground: 220 20% 90%;
+    --muted: 220 15% 25%;
+    --muted-foreground: 220 20% 70%;
+    --accent: 48 96% 60%;
+    --accent-foreground: 220 20% 10%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --border: 220 15% 25%;
+    --input: 220 15% 25%;
+    --ring: 220 80% 66%;
+    --chart-1: 211 91% 63%;
+    --chart-2: 173 80% 56%;
+    --chart-3: 43 96% 66%;
+    --chart-4: 52 98% 70%;
+    --chart-5: 27 89% 73%;
+    --sidebar-background: 220 25% 10%;
+    --sidebar-foreground: 220 20% 90%;
+    --sidebar-primary: 220 80% 66%;
+    --sidebar-primary-foreground: 220 20% 10%;
+    --sidebar-accent: 220 20% 15%;
+    --sidebar-accent-foreground: 220 20% 90%;
+    --sidebar-border: 220 20% 15%;
+    --sidebar-ring: 220 80% 66%;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak CSS variables for a consistent color palette
- use theme colors in navigation
- style dropdown and badges with the new palette
- clean up modal buttons and backgrounds

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686909fc2d6883248312c73086b51988