### PR TITLE
Update redshirt logic

### DIFF
--- a/frontend/components/AddPlayerModal.tsx
+++ b/frontend/components/AddPlayerModal.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Plus, Star } from "lucide-react";
 import { addPlayer } from "@/lib/api";
 import { useSeason } from "@/context/SeasonContext";
@@ -24,6 +25,7 @@ interface RecruitForm {
   weight: string;
   state: string;
   ovr_rating: number;
+  redshirt_used: boolean;
 }
 
 const recruitPositions = [
@@ -63,9 +65,10 @@ export function AddPlayerModal({ onPlayerAdded }: { onPlayerAdded: () => void })
     weight: "",
     state: "",
     ovr_rating: 70,
+    redshirt_used: false,
   });
 
-  const handleFormChange = (field: keyof RecruitForm, value: string | number) => {
+  const handleFormChange = (field: keyof RecruitForm, value: string | number | boolean) => {
     setForm({ ...form, [field]: value });
   };
 
@@ -115,6 +118,7 @@ export function AddPlayerModal({ onPlayerAdded }: { onPlayerAdded: () => void })
         weight: "",
         state: "",
         ovr_rating: 70,
+        redshirt_used: false,
       });
       setOpen(false);
       onPlayerAdded();
@@ -266,6 +270,10 @@ export function AddPlayerModal({ onPlayerAdded }: { onPlayerAdded: () => void })
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+              <div className="flex items-center gap-2 mt-4">
+                <Checkbox id="redshirt_used" checked={form.redshirt_used} onCheckedChange={checked => handleFormChange("redshirt_used", !!checked)} />
+                <Label htmlFor="redshirt_used" className="text-sm">Redshirt Already Used</Label>
               </div>
             </CardContent>
           </Card>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -168,6 +168,7 @@ export interface AddPlayerData {
   recruit_rank_nat?: number;
   state?: string;
   team_id: number;
+  redshirt_used?: boolean;
 }
 
 export interface UpdatePlayerData {

--- a/models.py
+++ b/models.py
@@ -88,6 +88,7 @@ class Player(db.Model):
     recruit_stars = db.Column(db.Integer)
     recruit_rank_nat = db.Column(db.Integer)
     state = db.Column(db.String(2))  # State abbreviation
+    redshirt_used = db.Column(db.Boolean, default=False)
     team_id = db.Column(db.Integer, db.ForeignKey('teams.team_id'))
     player_seasons = db.relationship('PlayerSeason', backref='player', lazy=True)
     award_winners = db.relationship('AwardWinner', backref='player', lazy=True)


### PR DESCRIPTION
## Summary
- add `redshirt_used` column for players to track career redshirt usage
- allow setting previous redshirt use when creating a player
- update redshirt endpoint to maintain career flag
- change season progression so only seasons actually redshirted stay the same class
- support redshirt-used checkbox in Add Player modal

## Testing
- `flake8`
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f66a21dd08324968944faaae2718b