### PR TITLE
Expand season schedule to 17 weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ To populate the database with initial data:
 python populate_db.py
 ```
 
+### Database Migration
+
+If you previously populated the database before the switch to a 17‑week season,
+run the migration script to create the missing weeks:
+```bash
+python migrations/add_weeks.py
+```
+
 ## API Endpoints
 
 The Flask backend provides RESTful API endpoints for all major features:

--- a/migrations/add_weeks.py
+++ b/migrations/add_weeks.py
@@ -1,0 +1,38 @@
+from app import app
+from extensions import db
+from models import Season, Team, Game
+
+TOTAL_WEEKS = 16  # Final week number (0-16)
+
+
+def add_missing_weeks():
+    """Add bye-week games so every season covers weeks 0-16."""
+    added = 0
+    with app.app_context():
+        seasons = Season.query.all()
+        teams = Team.query.all()
+        for season in seasons:
+            for week in range(TOTAL_WEEKS + 1):
+                for team in teams:
+                    exists = Game.query.filter(
+                        Game.season_id == season.season_id,
+                        Game.week == week,
+                        ((Game.home_team_id == team.team_id) |
+                         (Game.away_team_id == team.team_id))
+                    ).first()
+                    if exists:
+                        continue
+                    db.session.add(Game(
+                        season_id=season.season_id,
+                        week=week,
+                        home_team_id=team.team_id,
+                        away_team_id=None,
+                        game_type="Bye Week",
+                    ))
+                    added += 1
+        db.session.commit()
+    print(f"Added {added} bye-week games")
+
+
+if __name__ == "__main__":
+    add_missing_weeks()

--- a/populate_db.py
+++ b/populate_db.py
@@ -362,12 +362,13 @@ with app.app_context():
     # -------------------------
     # Initialize schedule with bye weeks for the user-controlled team only
     # -------------------------
-    REGULAR_SEASON_WEEKS = 12  # Typical number of regular-season weeks prior to playoffs
+    # Use 17 total weeks (0-16) for the schedule
+    REGULAR_SEASON_WEEKS = 16
     user_team = next((team for team in all_teams if team.is_user_controlled), None)
     
     if user_team:
         bye_games = []
-        for week in range(1, REGULAR_SEASON_WEEKS + 1):
+        for week in range(REGULAR_SEASON_WEEKS + 1):
             bye_games.append(Game(
                 season_id=season.season_id,
                 week=week,
@@ -377,7 +378,7 @@ with app.app_context():
             ))
         db.session.add_all(bye_games)
         db.session.commit()
-        print(f"Created bye-week schedule for {user_team.name}: {len(bye_games)} games across {REGULAR_SEASON_WEEKS} weeks.")
+        print(f"Created bye-week schedule for {user_team.name}: {len(bye_games)} games across {REGULAR_SEASON_WEEKS + 1} weeks.")
     else:
         print("Warning: No user-controlled team found for schedule creation.")
 

--- a/routes/seasons.py
+++ b/routes/seasons.py
@@ -85,9 +85,10 @@ def create_season() -> Response:
     db.session.commit()
 
     # --- NEW: Generate bye-week schedule for all teams ---
-    REGULAR_SEASON_WEEKS = 12
+    # Use a 17-week calendar (weeks 0-16)
+    TOTAL_SEASON_WEEKS = 16
     bye_games = []
-    for week in range(1, REGULAR_SEASON_WEEKS + 1):
+    for week in range(TOTAL_SEASON_WEEKS + 1):
         for team in teams:
             bye_games.append(Game(
                 season_id=new_season.season_id,
@@ -98,7 +99,7 @@ def create_season() -> Response:
             ))
     db.session.add_all(bye_games)
     db.session.commit()
-    print(f"Created bye-week schedule for new season: {len(bye_games)} games across {REGULAR_SEASON_WEEKS} weeks.")
+    print(f"Created bye-week schedule for new season: {len(bye_games)} games across {TOTAL_SEASON_WEEKS + 1} weeks.")
     
     # --- NEW: Automatically progress players from the previous season ---
     prev_season = Season.query.filter(Season.season_id < new_season.season_id).order_by(Season.season_id.desc()).first()


### PR DESCRIPTION
## Summary
- support 17‑week seasons when creating a new season
- seed initial database with weeks 0‑16
- add a migration script that backfills missing weeks
- document the migration process in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python migrations/add_weeks.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687169f96d888324ba5ca27ac9c3e215