### PR TITLE
Add optional bowl week

### DIFF
--- a/migrations/add_weeks.py
+++ b/migrations/add_weeks.py
@@ -5,11 +5,11 @@ from app import app
 from extensions import db
 from models import Season, Team, Game
 
-TOTAL_WEEKS = 16  # Final week number (0-16)
+TOTAL_WEEKS = 17  # Final week number (0-17)
 
 
 def add_missing_weeks():
-    """Add bye-week games so every season covers weeks 0-16, but only if a team has no game at all that week."""
+    """Add bye-week games so every season covers weeks 0-17, but only if a team has no game at all that week."""
     added = 0
     with app.app_context():
         seasons = Season.query.all()

--- a/populate_db.py
+++ b/populate_db.py
@@ -362,8 +362,8 @@ with app.app_context():
     # -------------------------
     # Initialize schedule with bye weeks for the user-controlled team only
     # -------------------------
-    # Use 17 total weeks (0-16) for the schedule
-    REGULAR_SEASON_WEEKS = 16
+    # Use 18 total weeks (0-17) for the schedule
+    REGULAR_SEASON_WEEKS = 17
     user_team = next((team for team in all_teams if team.is_user_controlled), None)
     
     if user_team:

--- a/populate_db_with_testing_data.py
+++ b/populate_db_with_testing_data.py
@@ -4,12 +4,12 @@ from models import Season, Conference, Team, TeamSeason, Player, PlayerSeason, G
 import random
 import os
 def backfill_all_season_games(tbd_team_id):
-    """Ensure every season has a full 17-week schedule."""
+    """Ensure every season has a full 18-week schedule."""
     seasons = Season.query.all()
     user_team = Team.query.filter_by(is_user_controlled=True).first()
     if not user_team: return
     for season in seasons:
-        for week in range(17): # Weeks 0-16
+        for week in range(18):  # Weeks 0-17
             game_exists = Game.query.filter_by(season_id=season.season_id, week=week).first()
             if not game_exists:
                 # Create a placeholder game with TBD teams

--- a/routes/seasons.py
+++ b/routes/seasons.py
@@ -85,8 +85,8 @@ def create_season() -> Response:
     db.session.commit()
 
     # --- NEW: Generate bye-week schedule for user-controlled team only ---
-    # Use a 17-week calendar (weeks 0-16)
-    TOTAL_SEASON_WEEKS = 16
+    # Use an 18-week calendar (weeks 0-17)
+    TOTAL_SEASON_WEEKS = 17
     user_team = next((team for team in teams if getattr(team, 'is_user_controlled', False)), None)
     bye_games = []
     if user_team:


### PR DESCRIPTION
## Summary
- extend schedule to use 18 weeks (0‑17)
- update migration and backfill scripts

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688601a4af908324a3295baf0921c58c